### PR TITLE
fix #12: added EN + CN links

### DIFF
--- a/content/docs/core/get-started/introduction.cn.mdx
+++ b/content/docs/core/get-started/introduction.cn.mdx
@@ -30,25 +30,25 @@ Dokploy 是一款稳定、易于使用的部署解决方案，旨在简化应用
 <Card
   title="安装"
   description="了解如何安装 Dokploy。"
-  href="/cn/get-started/installation"
+  href="/cn/docs/core/get-started/installation"
 />
 
 <Card
   title="应用"
   description="了解如何部署应用程序。"
-href="/cn/application/overview"
+href="/cn/docs/core/application/overview"
 />
 
 <Card
   title="数据库"
   description="了解如何部署数据库。"
-  href="/cn/databases/overview"
+  href="/cn/docs/core/databases/overview"
 />
 
 <Card
   title="Traefik"
   description="了解如何部署 Traefik。"
-  href="/cn/traefik/overview"
+  href="/cn/docs/core/traefik/overview"
 />
    
 </Cards>

--- a/content/docs/core/get-started/introduction.mdx
+++ b/content/docs/core/get-started/introduction.mdx
@@ -32,22 +32,22 @@ Please go to get started.
 
 <Cards>
   <Card
-    href="/get-started/installation"
+    href="/docs/core/get-started/installation"
     title="Installation"
     description="Learn how to install Dokploy."
   />
   <Card
-    href="/application/overview"
+    href="/docs/core/application/overview"
     title="Applications"
     description="Learn how to deploy applications."
   />
   <Card
-    href="/databases/overview"
+    href="/docs/core/databases/overview"
     title="Databases"
     description="Learn how to deploy databases."
   />
   <Card
-    href="/traefik/overview"
+    href="/docs/core/traefik/overview"
     title="Traefik"
     description="Learn how to deploy Traefik."
   />


### PR DESCRIPTION
Also found that this dokploy link redirects to home page, ignoring chosen lang
![Screenshot_20240626_161210](https://github.com/Dokploy/docs/assets/56293189/fc3ede6d-534b-4c5a-87cb-2a048e4d332a)

Don't know how to exactly fix it or where, so left it.
If anyone can help -- feel free to contribute in this PR
